### PR TITLE
Improve board HUD layout and turn visibility

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -186,6 +186,119 @@
   gap: 12px;
 }
 
+.board-hud {
+  width: min(88vw, 660px);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+  padding: 16px 18px;
+  border-radius: 20px;
+  background: rgba(14, 3, 38, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.38);
+  backdrop-filter: blur(18px);
+}
+
+.turn-card {
+  border-radius: 16px;
+  border: 1px solid;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  background: linear-gradient(155deg, rgba(56, 22, 120, 0.6), rgba(20, 7, 52, 0.85));
+}
+
+.turn-heading {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.turn-player {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.turn-slogan {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.65);
+  line-height: 1.35;
+}
+
+.hud-middle {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  justify-content: center;
+}
+
+.hud-timer,
+.hud-last-move {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: linear-gradient(150deg, rgba(80, 42, 158, 0.7), rgba(30, 8, 74, 0.95));
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  min-height: 72px;
+}
+
+.hud-timer-label,
+.hud-last-move-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.56);
+}
+
+.hud-timer-value {
+  font-size: 1.4rem;
+  font-weight: 800;
+  color: #f4f3ff;
+}
+
+.hud-last-move-value {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.88);
+  line-height: 1.3;
+}
+
+.timer-warning .hud-timer-value {
+  color: #ffd675;
+}
+
+.timer-critical .hud-timer-value {
+  color: #ff8b8b;
+  animation: timerPulse 0.8s ease-in-out infinite;
+}
+
+.hud-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  justify-content: center;
+}
+
+.hud-ready-button {
+  margin-top: 0;
+  width: 100%;
+  min-height: 48px;
+  font-size: 0.95rem;
+}
+
+.hud-ready-status {
+  font-size: 0.82rem;
+  color: rgba(255, 255, 255, 0.68);
+}
+
 .board {
   --board-size: 15;
   width: min(88vw, 660px);
@@ -244,6 +357,21 @@
   background: linear-gradient(165deg, rgba(255, 246, 216, 0.45), rgba(233, 191, 120, 0.18));
 }
 
+.board-cell.last-move {
+  border-color: rgba(255, 224, 148, 0.85);
+  box-shadow: 0 18px 28px rgba(107, 63, 20, 0.45);
+}
+
+.board-cell.last-move::after {
+  content: '';
+  position: absolute;
+  inset: 18%;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 239, 189, 0.9);
+  box-shadow: 0 0 0 6px rgba(255, 214, 109, 0.25);
+  animation: lastMovePulse 1.6s ease-in-out infinite;
+}
+
 .stone {
   width: 72%;
   aspect-ratio: 1 / 1;
@@ -259,6 +387,18 @@
 .stone.white {
   background: radial-gradient(circle at 30% 30%, #ffffff 0%, #d9dfe6 75%, #b4bec9 100%);
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.35);
+}
+
+.stone-last-move {
+  transform: scale(1.08);
+}
+
+.stone-last-move.black {
+  box-shadow: 0 0 0 6px rgba(255, 212, 113, 0.38), 0 6px 12px rgba(0, 0, 0, 0.45);
+}
+
+.stone-last-move.white {
+  box-shadow: 0 0 0 6px rgba(116, 210, 255, 0.35), 0 4px 10px rgba(0, 0, 0, 0.35);
 }
 
 .status-banner {
@@ -387,8 +527,41 @@
   font-weight: 700;
 }
 
-.ready-button {
+.ready-overview {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
   margin-top: 14px;
+}
+
+.ready-chip {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  transition: transform 0.2s ease;
+}
+
+.ready-chip.ready {
+  background: linear-gradient(135deg, rgba(126, 217, 87, 0.95), rgba(57, 198, 255, 0.95));
+  color: #0f1a29;
+  box-shadow: 0 10px 22px rgba(60, 200, 192, 0.35);
+}
+
+.ready-chip.waiting {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px dashed rgba(255, 255, 255, 0.25);
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.ready-button {
+  margin: 0;
   width: 100%;
   padding: 12px 18px;
   border-radius: 999px;
@@ -417,6 +590,10 @@
   margin-top: 10px;
   font-size: 0.85rem;
   color: rgba(255, 255, 255, 0.7);
+}
+
+.ready-status-compact {
+  margin-top: 14px;
 }
 
 .spectator-card {
@@ -621,6 +798,33 @@
   box-shadow: none;
 }
 
+@keyframes lastMovePulse {
+  0% {
+    transform: scale(0.94);
+    opacity: 0.9;
+  }
+  50% {
+    transform: scale(1.04);
+    opacity: 0.4;
+  }
+  100% {
+    transform: scale(0.94);
+    opacity: 0.9;
+  }
+}
+
+@keyframes timerPulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(0.96);
+    opacity: 0.55;
+  }
+}
+
 @media (max-width: 980px) {
   .layout {
     grid-template-columns: 1fr;
@@ -637,7 +841,8 @@
   }
 
   .board,
-  .status-banner {
+  .status-banner,
+  .board-hud {
     width: 100%;
   }
 }
@@ -662,5 +867,19 @@
 
   .skill-grid {
     grid-template-columns: 1fr;
+  }
+
+  .board-hud {
+    grid-template-columns: 1fr;
+    padding: 14px;
+    gap: 12px;
+  }
+
+  .hud-middle {
+    gap: 10px;
+  }
+
+  .hud-actions {
+    align-items: stretch;
   }
 }


### PR DESCRIPTION
## Summary
- add a board HUD that surfaces the active player, countdown timer, last move description, and ready control
- highlight the latest stone directly on the board and reorganize readiness info into clear status chips
- refresh desktop and mobile styles so skills, timers, and controls stay legible across breakpoints

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd3369f14c83288db90030bb79feda